### PR TITLE
:adhesive_bandage: Fix Markdown hyperlink markup

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,3 @@
 # netz39 Workshop git
 
-Dieses Projekt enthält die Präsentation für einen git Workshop im (netz39)[https://www.netz39.de]
+Dieses Projekt enthält die Präsentation für einen git Workshop im [netz39](https://www.netz39.de)

--- a/presentation.md
+++ b/presentation.md
@@ -155,9 +155,9 @@ Einen Computer mit dem Repo definierte Dinge tun lassen
 
 ## github: Actions Beispiele
 
-- (Veröffentlichung dieser Präsentation)[https://github.com/24367dfa/git-workshop/blob/main/.github/workflows/marp-to-pages.yml]
-- (Build und Release von Docker Containern)[https://github.com/FreifunkMD/md.freifunk.net-bind9/tree/main/.github/workflows]
-- (Versand der Reminder fürs Plenum)[https://github.com/netz39/istheuteplenum/blob/gh-pages/.github/workflows/meeting-reminder.yaml]
+- [Veröffentlichung dieser Präsentation](https://github.com/24367dfa/git-workshop/blob/main/.github/workflows/marp-to-pages.yml)
+- [Build und Release von Docker Containern](https://github.com/FreifunkMD/md.freifunk.net-bind9/tree/main/.github/workflows)
+- [Versand der Reminder fürs Plenum](https://github.com/netz39/istheuteplenum/blob/gh-pages/.github/workflows/meeting-reminder.yaml)
 
 ## Advanced: Conventional Commits
 
@@ -165,12 +165,12 @@ Einen Computer mit dem Repo definierte Dinge tun lassen
 
 Projekt unsere git history soll schöner werden
 
-(gitmoji.dev)[https://gitmoji.dev/]
+[gitmoji.dev](https://gitmoji.dev/)
 
 ## Links
 
-(git docs)[https://git-scm.com/docs]
-(oh-shit-git)[https://ohshitgit.com/]
+[git docs](https://git-scm.com/docsr)
+[oh-shit-git](https://ohshitgit.com/)
 
 ## Bildquellen
 


### PR DESCRIPTION
Help to memorize: URL can not have [ ] in them, because those are used to write IPv6 addresses, so those must be for the link text …

Link: https://[2a02:ec80:300:ed1a::1]/wiki/Markdown